### PR TITLE
add env for migration from older version

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,12 +2,22 @@
 # defaults file for sentry_selfhosted
 
 sentry_docker_compose_project_folder: /opt/docker/sentry
-sentry_version: 24.11.1
+sentry_version: 24.4.2
 sentry_bind: 9000
 
 sentry_env: {}
 sentry_mail: {}
 sentry_config: {}
 
-sentry_url: 
+sentry_url: "https://url.com"
 sentry_superusers: []
+
+# Controls whether install.sh automatically modifies sentry.conf.py during upgrades.
+# When Sentry introduces new infrastructure (e.g. migrating nodestore from Postgres to SeaweedFS),
+# the install script may need to patch the config. 
+#
+# "1" - apply changes automatically (recommended for fresh installs and upgrades)
+# "0" - skip automatic changes, you will need to update sentry.conf.py manually
+#
+# See: https://develop.sentry.dev/self-hosted/
+sentry_apply_automatic_config_updates: "0"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 # defaults file for sentry_selfhosted
 
 sentry_docker_compose_project_folder: /opt/docker/sentry
-sentry_version: 24.4.2
+sentry_version: 26.4.2
 sentry_bind: 9000
 
 sentry_env: {}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,13 +3,13 @@
   file:
     path: "{{ item }}"
     state: directory
-    mode: 0700
+    mode: 0755
   loop:
     - "{{ sentry_docker_compose_project_folder }}"
 
 - name: Checkout sentry self hosted docker-compose project
   git:
-    repo: https://github.com/getsentry/onpremise.git
+    repo: https://github.com/getsentry/self-hosted.git
     version: "{{ sentry_version }}"
     dest: "{{ sentry_docker_compose_project_folder }}"
     force: true
@@ -30,6 +30,8 @@
   command:
     chdir: "{{ sentry_docker_compose_project_folder }}"
     cmd: ./install.sh --no-report-self-hosted-issues --skip-user-creation
+  environment:
+    APPLY_AUTOMATIC_CONFIG_UPDATES: "{{ sentry_apply_automatic_config_updates }}"
   async: 600
   poll: 30
 


### PR DESCRIPTION
Add new env `APPLY_AUTOMATIC_CONFIG_UPDATES` for controls installation with new configs in new version Sentry
Fix name repo
Fix error install geoip with permission 700 on directories 